### PR TITLE
Add Chopper enchant

### DIFF
--- a/common/src/main/resources/assets/fallingtree/lang/en_us.json
+++ b/common/src/main/resources/assets/fallingtree/lang/en_us.json
@@ -185,9 +185,13 @@
   "text.autoconfig.fallingtree.option.tools.speedMultiplicand.@Tooltip[12]": "WARNING: If you are on a server, this either has to be set to 0",
   "text.autoconfig.fallingtree.option.tools.speedMultiplicand.@Tooltip[13]": "or every player should have the mod. Else they'll have a weird",
   "text.autoconfig.fallingtree.option.tools.speedMultiplicand.@Tooltip[14]": "effect of breaking the block but the block is still there.",
+  "text.autoconfig.fallingtree.option.tools.requireEnchant": "Require enchant",
+  "text.autoconfig.fallingtree.option.tools.requireEnchant.@Tooltip[1]": "Define if the tool must be enchanted in order to be able",
+  "text.autoconfig.fallingtree.option.tools.requireEnchant.@Tooltip[2]": "to chop trees with it (whitelist/blacklist still applies).",
   "chat.fallingtree.tree_too_big": "This tree is too big won't be scanned further (max scan size: %d)",
   "chat.fallingtree.break_tree_too_big": "This tree is too big and can't be broken in one hit (max tree size: %d)",
   "chat.fallingtree.prevented_break_tool": "Your tool is about to break, go repair it or get a new one.",
   "chat.fallingtree.search_aborted": "Tree detection stopped, reason: ",
-  "chat.fallingtree.search_aborted.adjacent": "Found block %s that isn't whitelisted in the adjacent blocks."
+  "chat.fallingtree.search_aborted.adjacent": "Found block %s that isn't whitelisted in the adjacent blocks.",
+  "enchantment.fallingtree.chopper": "Chopper"
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 dependencies {
     minecraft(libs.minecraft)
     mappings(loom.officialMojangMappings())
+
     modImplementation(libs.bundles.fabric)
+
     implementation(project(":common"))
 
     modImplementation(libs.modmenu) {

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/FallingTree.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/FallingTree.java
@@ -2,6 +2,7 @@ package fr.raksrinana.fallingtree.fabric;
 
 import fr.raksrinana.fallingtree.fabric.config.Configuration;
 import fr.raksrinana.fallingtree.fabric.config.validator.Validators;
+import fr.raksrinana.fallingtree.fabric.enchant.ChopperEnchantment;
 import fr.raksrinana.fallingtree.fabric.leaves.LeafBreakingHandler;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
@@ -10,6 +11,9 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.enchantment.Enchantment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import static java.util.stream.Collectors.toList;
@@ -18,6 +22,12 @@ public class FallingTree implements ModInitializer{
 	public static final String MOD_ID = "fallingtree";
 	public static final Logger logger = LogManager.getLogger(MOD_ID);
 	public static Configuration config;
+	
+	public static Enchantment CHOPPER_ENCHANTMENT = Registry.register(
+			Registry.ENCHANTMENT,
+			new ResourceLocation(MOD_ID, "chopper"),
+			new ChopperEnchantment()
+	);
 	
 	@Override
 	public void onInitialize(){

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/config/ToolConfiguration.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/config/ToolConfiguration.java
@@ -30,9 +30,12 @@ public class ToolConfiguration{
 			"INFO: Only in instantaneous mode")
 	public boolean preserve = false;
 	@Tooltip(count = 4)
-	@Comment("When set to true, the mod will be activated no matter what you have in your hand. \n" +
+	@Comment("When set to true, the mod will be activated no matter what you have in your hand.\n" +
 			"INFO: Blacklist still can be use to restrict some tools.")
 	public boolean ignoreTools = false;
+	@Tooltip(count = 2)
+	@Comment("Define if the tool must be enchanted in order to be able to chop trees with it (whitelist/blacklist still applies).")
+	public boolean requireEnchant = true;
 	@Tooltip(count = 7)
 	@Comment("""
 			Defines the number of times the damage is applied to the tool.\s

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/enchant/ChopperEnchantment.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/enchant/ChopperEnchantment.java
@@ -1,0 +1,16 @@
+package fr.raksrinana.fallingtree.fabric.enchant;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+
+public class ChopperEnchantment extends Enchantment{
+	public ChopperEnchantment(){
+		super(Rarity.COMMON, EnchantmentCategory.DIGGER, new EquipmentSlot[]{EquipmentSlot.MAINHAND});
+	}
+	
+	public boolean canEnchant(ItemStack itemStack){
+		return true;
+	}
+}

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/FallingTree.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/FallingTree.java
@@ -2,11 +2,13 @@ package fr.raksrinana.fallingtree.forge;
 
 import fr.raksrinana.fallingtree.forge.config.Config;
 import fr.raksrinana.fallingtree.forge.config.cloth.ClothConfigHook;
+import fr.raksrinana.fallingtree.forge.enchant.FallingTreeEnchantments;
 import net.minecraftforge.fml.IExtensionPoint.DisplayTest;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.network.NetworkConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,5 +35,8 @@ public class FallingTree{
 				logger.error("Failed to hook into ClothConfig", e);
 			}
 		}
+		
+		var eventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		FallingTreeEnchantments.register(eventBus);
 	}
 }

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/config/ToolConfiguration.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/config/ToolConfiguration.java
@@ -14,6 +14,10 @@ public class ToolConfiguration{
 			"When set to true, the mod will be activated no matter what you have in your hand.",
 			"INFO: Blacklist still can be use to restrict some tools."
 	};
+	private static final String[] DESC_REQUIRE_ENCHANT = {
+			"Define if the tool must be enchanted in order to be able",
+			"to chop trees with it (whitelist/blacklist still applies)."
+	};
 	private static final String[] DESC_WHITELISTED = {
 			"Additional list of tools that can be used to chop down a tree.",
 			"INFO: Items marked with the axe tag will already be whitelisted."
@@ -53,6 +57,7 @@ public class ToolConfiguration{
 	private final ForgeConfigSpec.ConfigValue<List<? extends String>> blacklisted;
 	private final ForgeConfigSpec.BooleanValue preserve;
 	private final ForgeConfigSpec.BooleanValue ignoreTools;
+	private final ForgeConfigSpec.BooleanValue requireEnchant;
 	private final ForgeConfigSpec.DoubleValue damageMultiplicand;
 	private final ForgeConfigSpec.EnumValue<DamageRounding> damageRounding;
 	private final ForgeConfigSpec.DoubleValue speedMultiplicand;
@@ -60,6 +65,8 @@ public class ToolConfiguration{
 	public ToolConfiguration(ForgeConfigSpec.Builder builder){
 		ignoreTools = builder.comment(DESC_IGNORE_TOOLS)
 				.define("ignore_tools", false);
+		requireEnchant = builder.comment(DESC_REQUIRE_ENCHANT)
+				.define("require_enchant", true);
 		whitelisted = builder.comment(DESC_WHITELISTED)
 				.defineList("whitelisted", Lists.newArrayList(), Objects::nonNull);
 		blacklisted = builder.comment(DESC_BLACKLISTED)
@@ -106,6 +113,10 @@ public class ToolConfiguration{
 		ignoreTools.set(value);
 	}
 	
+	public void setRequireEnchant(Boolean value){
+		requireEnchant.set(value);
+	}
+	
 	public void setPreserve(Boolean value){
 		preserve.set(value);
 	}
@@ -120,6 +131,10 @@ public class ToolConfiguration{
 	
 	public boolean isPreserve(){
 		return preserve.get();
+	}
+	
+	public boolean isRequireEnchant(){
+		return requireEnchant.get();
 	}
 	
 	public boolean isIgnoreTools(){

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/config/cloth/ClothConfigHook.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/config/cloth/ClothConfigHook.java
@@ -207,28 +207,28 @@ public class ClothConfigHook{
 				.setSaveConsumer(config::setAdjacentStopMode)
 				.build();
 
-		var tools = builder.getOrCreateCategory(new TranslatableComponent("text.autoconfig.fallingtree.category.trees"));
-		tools.addEntry(breakModeEntry);
-		tools.addEntry(detectionModeEntry);
-		tools.addEntry(whitelistedLogsEntry);
-		tools.addEntry(blacklistedLogsEntry);
-		tools.addEntry(whitelistedLeavesEntry);
-		tools.addEntry(whitelistedNonDecayLeavesEntry);
-		tools.addEntry(blacklistedLeavesEntry);
-		tools.addEntry(maxScanSizeEntry);
-		tools.addEntry(maxSizeEntry);
-		tools.addEntry(maxSizeActionEntry);
-		tools.addEntry(breakOrderEntry);
-		tools.addEntry(treeBreakingEntry);
-		tools.addEntry(leavesBreakingEntry);
-		tools.addEntry(leavesBreakingForceRadiusEntry);
-		tools.addEntry(minimumLeavesAroundRequiredEntry);
-		tools.addEntry(allowMixedLogsEntry);
-		tools.addEntry(breakNetherTreeWartsEntry);
-		tools.addEntry(instantlyBreakWartsEntry);
-		tools.addEntry(searchAreaRadiusEntry);
-		tools.addEntry(whitelistedAdjacentBlocks);
-		tools.addEntry(adjacentStopModeEntry);
+		var trees = builder.getOrCreateCategory(new TranslatableComponent("text.autoconfig.fallingtree.category.trees"));
+		trees.addEntry(breakModeEntry);
+		trees.addEntry(detectionModeEntry);
+		trees.addEntry(whitelistedLogsEntry);
+		trees.addEntry(blacklistedLogsEntry);
+		trees.addEntry(whitelistedLeavesEntry);
+		trees.addEntry(whitelistedNonDecayLeavesEntry);
+		trees.addEntry(blacklistedLeavesEntry);
+		trees.addEntry(maxScanSizeEntry);
+		trees.addEntry(maxSizeEntry);
+		trees.addEntry(maxSizeActionEntry);
+		trees.addEntry(breakOrderEntry);
+		trees.addEntry(treeBreakingEntry);
+		trees.addEntry(leavesBreakingEntry);
+		trees.addEntry(leavesBreakingForceRadiusEntry);
+		trees.addEntry(minimumLeavesAroundRequiredEntry);
+		trees.addEntry(allowMixedLogsEntry);
+		trees.addEntry(breakNetherTreeWartsEntry);
+		trees.addEntry(instantlyBreakWartsEntry);
+		trees.addEntry(searchAreaRadiusEntry);
+		trees.addEntry(whitelistedAdjacentBlocks);
+		trees.addEntry(adjacentStopModeEntry);
 	}
 	
 	@OnlyIn(Dist.CLIENT)
@@ -240,6 +240,12 @@ public class ClothConfigHook{
 				.setDefaultValue(false)
 				.setTooltip(getTooltips("tools", "ignoreTools", 4))
 				.setSaveConsumer(config::setIgnoreTools)
+				.build();
+		var requireEnchantEntry = builder.entryBuilder()
+				.startBooleanToggle(new TranslatableComponent(getFieldName("tools", "requireEnchant")), config.isRequireEnchant())
+				.setDefaultValue(true)
+				.setTooltip(getTooltips("tools", "requireEnchant", 2))
+				.setSaveConsumer(config::setRequireEnchant)
 				.build();
 		var whitelistedEntry = builder.entryBuilder()
 				.startStrList(new TranslatableComponent(getFieldName("tools", "whitelisted")), config.getWhitelisted())
@@ -286,6 +292,7 @@ public class ClothConfigHook{
 
 		var tools = builder.getOrCreateCategory(new TranslatableComponent("text.autoconfig.fallingtree.category.tools"));
 		tools.addEntry(ignoreToolsEntry);
+		tools.addEntry(requireEnchantEntry);
 		tools.addEntry(whitelistedEntry);
 		tools.addEntry(blacklistedEntry);
 		tools.addEntry(damageMultiplicandEntry);

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
@@ -1,0 +1,19 @@
+package fr.raksrinana.fallingtree.forge.enchant;
+
+import fr.raksrinana.fallingtree.forge.FallingTree;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentCategory;
+
+public class ChopperEnchantment extends Enchantment{
+	public ChopperEnchantment(){
+		super(Rarity.COMMON, EnchantmentCategory.DIGGER, new EquipmentSlot[]{EquipmentSlot.MAINHAND});
+		setRegistryName(new ResourceLocation(FallingTree.MOD_ID, "chopper"));
+	}
+	
+	public boolean canEnchant(ItemStack itemStack){
+		return true;
+	}
+}

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
@@ -1,7 +1,5 @@
 package fr.raksrinana.fallingtree.forge.enchant;
 
-import fr.raksrinana.fallingtree.forge.FallingTree;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -10,7 +8,6 @@ import net.minecraft.world.item.enchantment.EnchantmentCategory;
 public class ChopperEnchantment extends Enchantment{
 	public ChopperEnchantment(){
 		super(Rarity.COMMON, EnchantmentCategory.DIGGER, new EquipmentSlot[]{EquipmentSlot.MAINHAND});
-		setRegistryName(new ResourceLocation(FallingTree.MOD_ID, "chopper"));
 	}
 	
 	public boolean canEnchant(ItemStack itemStack){

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/FallingTreeEnchantments.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/FallingTreeEnchantments.java
@@ -1,0 +1,24 @@
+package fr.raksrinana.fallingtree.forge.enchant;
+
+import fr.raksrinana.fallingtree.forge.FallingTree;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ObjectHolder;
+
+@ObjectHolder(FallingTree.MOD_ID)
+public class FallingTreeEnchantments{
+	public static final Enchantment chopper = null;
+	
+	@Mod.EventBusSubscriber(modid = FallingTree.MOD_ID)
+	public static class RegistrationHandler
+	{
+		@SubscribeEvent
+		public static void onEvent(RegistryEvent.Register<Enchantment> event)
+		{
+			var registry = event.getRegistry();
+			registry.register(new ChopperEnchantment());
+		}
+	}
+}

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/FallingTreeEnchantments.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/FallingTreeEnchantments.java
@@ -2,23 +2,17 @@ package fr.raksrinana.fallingtree.forge.enchant;
 
 import fr.raksrinana.fallingtree.forge.FallingTree;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.registries.ObjectHolder;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
-@ObjectHolder(FallingTree.MOD_ID)
 public class FallingTreeEnchantments{
-	public static final Enchantment chopper = null;
+	public static final DeferredRegister<Enchantment> ENCHANTMENTS = DeferredRegister.create(ForgeRegistries.ENCHANTMENTS, FallingTree.MOD_ID);
 	
-	@Mod.EventBusSubscriber(modid = FallingTree.MOD_ID)
-	public static class RegistrationHandler
-	{
-		@SubscribeEvent
-		public static void onEvent(RegistryEvent.Register<Enchantment> event)
-		{
-			var registry = event.getRegistry();
-			registry.register(new ChopperEnchantment());
-		}
+	public static RegistryObject<Enchantment> CHOPPER_ENCHANTMENT = ENCHANTMENTS.register("chopper", ChopperEnchantment::new);
+	
+	public static void register(IEventBus eventBus) {
+		ENCHANTMENTS.register(eventBus);
 	}
 }

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/utils/FallingTreeUtils.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/utils/FallingTreeUtils.java
@@ -2,6 +2,7 @@ package fr.raksrinana.fallingtree.forge.utils;
 
 import fr.raksrinana.fallingtree.forge.config.Config;
 import fr.raksrinana.fallingtree.forge.config.ConfigCache;
+import fr.raksrinana.fallingtree.forge.enchant.FallingTreeEnchantments;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -12,6 +13,7 @@ import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -97,7 +99,7 @@ public class FallingTreeUtils{
 	
 	public static boolean isLeafBlock(@Nonnull Block block){
 		var isWhitelistedBlock = LEAVES.contains(block)
-				|| Config.COMMON.getTrees().getWhitelistedLeaveBlocks().stream().anyMatch(leaf -> leaf.equals(block));
+		                         || Config.COMMON.getTrees().getWhitelistedLeaveBlocks().stream().anyMatch(leaf -> leaf.equals(block));
 		if(isWhitelistedBlock){
 			var isBlacklistedBlock = Config.COMMON.getTrees().getBlacklistedLeaveBlocks().stream().anyMatch(leaf -> leaf.equals(block));
 			return !isBlacklistedBlock;
@@ -109,14 +111,25 @@ public class FallingTreeUtils{
 		var toolConfiguration = Config.COMMON.getTools();
 		var heldItemStack = player.getItemInHand(MAIN_HAND);
 		var heldItem = heldItemStack.getItem();
+		
 		var isWhitelistedTool = toolConfiguration.isIgnoreTools()
-				|| heldItem.getDestroySpeed(heldItemStack, aimedBlockState) > 1f
-				|| toolConfiguration.getWhitelistedItems().stream().anyMatch(tool -> tool.equals(heldItem));
-		if(isWhitelistedTool){
-			var isBlacklistedTool = toolConfiguration.getBlacklistedItems().stream().anyMatch(tool -> tool.equals(heldItem));
-			return !isBlacklistedTool;
+		                        || heldItem.getDestroySpeed(heldItemStack, aimedBlockState) > 1f
+		                        || toolConfiguration.getWhitelistedItems().stream().anyMatch(tool -> tool.equals(heldItem));
+		if(!isWhitelistedTool){
+			return false;
 		}
-		return false;
+		
+		var isBlacklistedTool = toolConfiguration.getBlacklistedItems().stream().anyMatch(tool -> tool.equals(heldItem));
+		if(isBlacklistedTool){
+			return false;
+		}
+		
+		var isToolChopperEnchanted = EnchantmentHelper.getItemEnchantmentLevel(FallingTreeEnchantments.chopper, heldItemStack) > 0;
+		if(toolConfiguration.isRequireEnchant() && !isToolChopperEnchanted){
+			return false;
+		}
+		
+		return true;
 	}
 	
 	public static TreePartType getTreePart(Block checkBlock){
@@ -141,7 +154,7 @@ public class FallingTreeUtils{
 	
 	public static boolean isLogBlock(Block block){
 		var isWhitelistedBlock = ConfigCache.getInstance().getDefaultLogs().stream().anyMatch(log -> log.equals(block))
-				|| Config.COMMON.getTrees().getWhitelistedLogBlocks().stream().anyMatch(log -> log.equals(block));
+		                         || Config.COMMON.getTrees().getWhitelistedLogBlocks().stream().anyMatch(log -> log.equals(block));
 		if(isWhitelistedBlock){
 			var isBlacklistedBlock = Config.COMMON.getTrees().getBlacklistedLogBlocks().stream().anyMatch(log -> log.equals(block));
 			return !isBlacklistedBlock;

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/utils/FallingTreeUtils.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/utils/FallingTreeUtils.java
@@ -124,7 +124,7 @@ public class FallingTreeUtils{
 			return false;
 		}
 		
-		var isToolChopperEnchanted = EnchantmentHelper.getItemEnchantmentLevel(FallingTreeEnchantments.chopper, heldItemStack) > 0;
+		var isToolChopperEnchanted = EnchantmentHelper.getItemEnchantmentLevel(FallingTreeEnchantments.CHOPPER_ENCHANTMENT.get(), heldItemStack) > 0;
 		if(toolConfiguration.isRequireEnchant() && !isToolChopperEnchanted){
 			return false;
 		}


### PR DESCRIPTION
This adds a new `Chopper` enchant. This is required by default on tools in order for the chopping to happen. Whitelist/blacklists still applies.

Close #99