### PR TITLE
Change defaults to not require/register the enchant

### DIFF
--- a/common/src/main/java/fr/mrcraftcod/fallingtree/common/config/Configuration.java
+++ b/common/src/main/java/fr/mrcraftcod/fallingtree/common/config/Configuration.java
@@ -29,7 +29,7 @@ public class Configuration{
 	@Expose
 	private boolean breakInCreative = false;
 	@Expose
-	private boolean registerEnchant = true;
+	private boolean registerEnchant = false;
 	@Expose
 	@NotNull
 	private NotificationMode notificationMode = NotificationMode.ACTION_BAR;

--- a/common/src/main/java/fr/mrcraftcod/fallingtree/common/config/ToolConfiguration.java
+++ b/common/src/main/java/fr/mrcraftcod/fallingtree/common/config/ToolConfiguration.java
@@ -25,7 +25,7 @@ public class ToolConfiguration{
 	@Expose
 	private boolean ignoreTools = false;
 	@Expose
-	private boolean requireEnchant = true;
+	private boolean requireEnchant = false;
 	@Expose
 	private double damageMultiplicand = 1d;
 	@Expose

--- a/common/src/main/resources/assets/fallingtree/lang/en_us.json
+++ b/common/src/main/resources/assets/fallingtree/lang/en_us.json
@@ -206,6 +206,7 @@
   "text.autoconfig.fallingtree.option.tools.requireEnchant": "Require enchant",
   "text.autoconfig.fallingtree.option.tools.requireEnchant.@Tooltip[0]": "Define if the tool must be enchanted in order to be able",
   "text.autoconfig.fallingtree.option.tools.requireEnchant.@Tooltip[1]": "to chop trees with it (allow/deny list still apply).",
+  "text.autoconfig.fallingtree.option.tools.requireEnchant.@Tooltip[2]": "INFO: If set to true, you'll also need registerEnchant to true",
   "text.autoconfig.fallingtree.category.player": "Player",
   "text.autoconfig.fallingtree.option.player.allowedTags": "Required player tagss",
   "text.autoconfig.fallingtree.option.player.allowedTags.@Tooltip[0]": "Define a list of tags that the player should",

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/cloth/ClothConfigHook.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/cloth/ClothConfigHook.java
@@ -64,7 +64,7 @@ public class ClothConfigHook extends ClothHookBase{
 				.build();
 		var registerEnchantEntry = builder.entryBuilder()
 				.startBooleanToggle(new TranslatableComponent(getFieldName(null, "registerEnchant")), config.isRegisterEnchant())
-				.setDefaultValue(true)
+				.setDefaultValue(false)
 				.setTooltip(getTooltips(null, "registerEnchant", 11))
 				.setSaveConsumer(config::setRegisterEnchant)
 				.build();
@@ -262,8 +262,8 @@ public class ClothConfigHook extends ClothHookBase{
 				.build();
 		var requireEnchantEntry = builder.entryBuilder()
 				.startBooleanToggle(new TranslatableComponent(getFieldName("tools", "requireEnchant")), config.isRequireEnchant())
-				.setDefaultValue(true)
-				.setTooltip(getTooltips("tools", "requireEnchant", 2))
+				.setDefaultValue(false)
+				.setTooltip(getTooltips("tools", "requireEnchant", 3))
 				.setSaveConsumer(config::setRequireEnchant)
 				.build();
 		var allowedEntry = builder.entryBuilder()

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/cloth/ClothConfigHook.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/cloth/ClothConfigHook.java
@@ -64,7 +64,7 @@ public class ClothConfigHook extends ClothHookBase{
 				.build();
 		var registerEnchantEntry = builder.entryBuilder()
 				.startBooleanToggle(new TranslatableComponent(getFieldName(null, "registerEnchant")), config.isRegisterEnchant())
-				.setDefaultValue(true)
+				.setDefaultValue(false)
 				.setTooltip(getTooltips(null, "registerEnchant", 11))
 				.setSaveConsumer(config::setRegisterEnchant)
 				.build();
@@ -262,8 +262,8 @@ public class ClothConfigHook extends ClothHookBase{
 				.build();
 		var requireEnchantEntry = builder.entryBuilder()
 				.startBooleanToggle(new TranslatableComponent(getFieldName("tools", "requireEnchant")), config.isRequireEnchant())
-				.setDefaultValue(true)
-				.setTooltip(getTooltips("tools", "requireEnchant", 2))
+				.setDefaultValue(false)
+				.setTooltip(getTooltips("tools", "requireEnchant", 3))
 				.setSaveConsumer(config::setRequireEnchant)
 				.build();
 		var allowedEntry = builder.entryBuilder()


### PR DESCRIPTION
New people / people transitioning from 2.x.x will have the enchant disable.
This reduces confusion for them as to why the mod doesn't work.

People that already transitioned to 3.x won't be affected by this.