### PR TITLE
Fix a bug involving having the SNEAK_MODE option being the reverse of what the configuration says

### DIFF
--- a/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
@@ -48,7 +48,7 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 		if(player.isCreative() && !getConfiguration().isBreakInCreative()){
 			return false;
 		}
-		if(configuration.getSneakMode().test(player.isCrouching())){
+		if(!configuration.getSneakMode().test(player.isCrouching())){
 			return false;
 		}
 		if(!playerHasRequiredTags(player)){


### PR DESCRIPTION
Adds an inversion operator to the check to the SNEAK_MODE test to fix the bug in the title.