### PR TITLE
Some tools are not considered as axes in the anvil

### DIFF
--- a/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
@@ -44,7 +44,7 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 		player.sendMessage(component, getConfiguration().getNotificationMode());
 	}
 	
-	public boolean isPlayerInRightState(@NotNull IPlayer player, @NotNull IBlockState blockState){
+	public boolean isPlayerInRightState(@NotNull IPlayer player){
 		if(player.isCreative() && !getConfiguration().isBreakInCreative()){
 			return false;
 		}
@@ -54,7 +54,7 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 		if(!playerHasRequiredTags(player)){
 			return false;
 		}
-		return canPlayerBreakTree(player, blockState);
+		return canPlayerBreakTree(player);
 	}
 	
 	private boolean playerHasRequiredTags(@NotNull IPlayer player){
@@ -67,9 +67,8 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 		return tags.stream().anyMatch(playerTags::contains);
 	}
 	
-	public boolean canPlayerBreakTree(@NotNull IPlayer player, @NotNull IBlockState aimedBlockState){
+	public boolean canPlayerBreakTree(@NotNull IPlayer player){
 		var heldItemStack = player.getMainHandItem();
-		var heldItem = heldItemStack.getItem();
 		
 		if(!isValidTool(heldItemStack)){
 			return false;

--- a/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/FallingTreeCommon.java
@@ -70,9 +70,8 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 	public boolean canPlayerBreakTree(@NotNull IPlayer player, @NotNull IBlockState aimedBlockState){
 		var heldItemStack = player.getMainHandItem();
 		var heldItem = heldItemStack.getItem();
-		var isCorrectTool = heldItem.getDestroySpeed(heldItemStack, aimedBlockState) > 1.0f;
 		
-		if(!isValidTool(heldItemStack, isCorrectTool)){
+		if(!isValidTool(heldItemStack)){
 			return false;
 		}
 		
@@ -84,12 +83,12 @@ public abstract class FallingTreeCommon<D extends Enum<D>>{
 		return true;
 	}
 	
-	public boolean isValidTool(@NotNull IItemStack heldItemStack, boolean isCorrectTool){
+	public boolean isValidTool(@NotNull IItemStack heldItemStack){
 		var toolConfiguration = getConfiguration().getTools();
 		var heldItem = heldItemStack.getItem();
 		
 		var isAllowedTool = toolConfiguration.isIgnoreTools()
-		                    || isCorrectTool
+		                    || heldItem.isAxe()
 		                    || toolConfiguration.getAllowedItems(this).stream().anyMatch(tool -> tool.equals(heldItem));
 		if(!isAllowedTool){
 			return false;

--- a/common/src/main/java/fr/raksrinana/fallingtree/common/tree/TreeHandler.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/tree/TreeHandler.java
@@ -9,7 +9,6 @@ import fr.raksrinana.fallingtree.common.tree.breaking.ShiftDownTreeBreakingHandl
 import fr.raksrinana.fallingtree.common.tree.builder.TreeTooBigException;
 import fr.raksrinana.fallingtree.common.utils.CacheSpeed;
 import fr.raksrinana.fallingtree.common.wrapper.IBlockPos;
-import fr.raksrinana.fallingtree.common.wrapper.IBlockState;
 import fr.raksrinana.fallingtree.common.wrapper.ILevel;
 import fr.raksrinana.fallingtree.common.wrapper.IPlayer;
 import lombok.RequiredArgsConstructor;
@@ -38,8 +37,7 @@ public class TreeHandler{
 			return Optional.empty();
 		}
 		
-		var blockState = level.getBlockState(blockPos);
-		if(!mod.isPlayerInRightState(player, blockState)){
+		if(!mod.isPlayerInRightState(player)){
 			return Optional.empty();
 		}
 		
@@ -73,14 +71,14 @@ public class TreeHandler{
 	}
 	
 	@NotNull
-	public Optional<Float> getBreakSpeed(@NotNull IPlayer player, @NotNull IBlockState blockState, @NotNull IBlockPos blockPos, float originalSpeed){
+	public Optional<Float> getBreakSpeed(@NotNull IPlayer player, @NotNull IBlockPos blockPos, float originalSpeed){
 		if(!mod.getConfiguration().getTrees().isTreeBreaking()){
 			return Optional.empty();
 		}
 		if(mod.getConfiguration().getTrees().getBreakMode() != BreakMode.INSTANTANEOUS){
 			return Optional.empty();
 		}
-		if(!mod.isPlayerInRightState(player, blockState)){
+		if(!mod.isPlayerInRightState(player)){
 			return Optional.empty();
 		}
 		

--- a/common/src/main/java/fr/raksrinana/fallingtree/common/wrapper/IItem.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/wrapper/IItem.java
@@ -3,6 +3,8 @@ package fr.raksrinana.fallingtree.common.wrapper;
 import org.jetbrains.annotations.NotNull;
 
 public interface IItem extends IWrapper{
+	boolean isAxe();
+	
 	boolean isAir();
 	
 	float getDestroySpeed(@NotNull IItemStack itemStack, @NotNull IBlockState blockState);

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/common/wrapper/ItemWrapper.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/common/wrapper/ItemWrapper.java
@@ -5,6 +5,7 @@ import fr.raksrinana.fallingtree.common.wrapper.IItem;
 import fr.raksrinana.fallingtree.common.wrapper.IItemStack;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.minecraft.world.item.AxeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -16,6 +17,11 @@ public class ItemWrapper implements IItem{
 	@NotNull
 	@Getter
 	private final Item raw;
+	
+	@Override
+	public boolean isAxe(){
+		return raw instanceof AxeItem;
+	}
 	
 	@Override
 	public boolean isAir(){

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/enchant/ChopperEnchantment.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/enchant/ChopperEnchantment.java
@@ -38,6 +38,6 @@ public class ChopperEnchantment extends Enchantment{
 	
 	@Override
 	public boolean canEnchant(@NotNull ItemStack stack){
-		return mod.isValidTool(new ItemStackWrapper(stack), false);
+		return mod.isValidTool(new ItemStackWrapper(stack));
 	}
 }

--- a/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/mixin/AbstractBlockMixin.java
+++ b/fabric/src/main/java/fr/raksrinana/fallingtree/fabric/mixin/AbstractBlockMixin.java
@@ -2,7 +2,6 @@ package fr.raksrinana.fallingtree.fabric.mixin;
 
 import fr.raksrinana.fallingtree.fabric.FallingTree;
 import fr.raksrinana.fallingtree.fabric.common.wrapper.BlockPosWrapper;
-import fr.raksrinana.fallingtree.fabric.common.wrapper.BlockStateWrapper;
 import fr.raksrinana.fallingtree.fabric.common.wrapper.PlayerWrapper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
@@ -19,10 +18,9 @@ public abstract class AbstractBlockMixin{
 	@Inject(method = "getDestroyProgress", at = @At(value = "TAIL"), cancellable = true)
 	public void calcBlockBreakingDelta(BlockState state, Player player, BlockGetter level, BlockPos pos, CallbackInfoReturnable<Float> callbackInfoReturnable){
 		var wrappedPlayer = new PlayerWrapper(player);
-		var wrappedState = new BlockStateWrapper(state);
 		var wrappedPos = new BlockPosWrapper(pos);
 		
-		var result = FallingTree.getMod().getTreeHandler().getBreakSpeed(wrappedPlayer, wrappedState, wrappedPos, callbackInfoReturnable.getReturnValue());
+		var result = FallingTree.getMod().getTreeHandler().getBreakSpeed(wrappedPlayer, wrappedPos, callbackInfoReturnable.getReturnValue());
 		if(result.isEmpty()){
 			return;
 		}

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/common/wrapper/ItemWrapper.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/common/wrapper/ItemWrapper.java
@@ -5,6 +5,7 @@ import fr.raksrinana.fallingtree.common.wrapper.IItem;
 import fr.raksrinana.fallingtree.common.wrapper.IItemStack;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.minecraft.world.item.AxeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -16,6 +17,11 @@ public class ItemWrapper implements IItem{
 	@NotNull
 	@Getter
 	private final Item raw;
+	
+	@Override
+	public boolean isAxe(){
+		return raw instanceof AxeItem;
+	}
 	
 	@Override
 	public boolean isAir(){

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/enchant/ChopperEnchantment.java
@@ -38,6 +38,6 @@ public class ChopperEnchantment extends Enchantment{
 	
 	@Override
 	public boolean canApplyAtEnchantingTable(@NotNull ItemStack stack){
-		return mod.isValidTool(new ItemStackWrapper(stack), false);
+		return mod.isValidTool(new ItemStackWrapper(stack));
 	}
 }

--- a/forge/src/main/java/fr/raksrinana/fallingtree/forge/event/BlockBreakListener.java
+++ b/forge/src/main/java/fr/raksrinana/fallingtree/forge/event/BlockBreakListener.java
@@ -2,7 +2,6 @@ package fr.raksrinana.fallingtree.forge.event;
 
 import fr.raksrinana.fallingtree.common.FallingTreeCommon;
 import fr.raksrinana.fallingtree.forge.common.wrapper.BlockPosWrapper;
-import fr.raksrinana.fallingtree.forge.common.wrapper.BlockStateWrapper;
 import fr.raksrinana.fallingtree.forge.common.wrapper.LevelWrapper;
 import fr.raksrinana.fallingtree.forge.common.wrapper.PlayerWrapper;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +23,9 @@ public class BlockBreakListener{
 		}
 		
 		var wrappedPlayer = new PlayerWrapper(event.getPlayer());
-		var wrappedState = new BlockStateWrapper(event.getState());
 		var wrappedPos = new BlockPosWrapper(event.getPos());
 		
-		var result = mod.getTreeHandler().getBreakSpeed(wrappedPlayer, wrappedState, wrappedPos, event.getNewSpeed());
+		var result = mod.getTreeHandler().getBreakSpeed(wrappedPlayer, wrappedPos, event.getNewSpeed());
 		if(result.isEmpty()){
 			return;
 		}


### PR DESCRIPTION
This basically reverts #197.

The issue is that when we want to know what a correct tool is, we previously were taking into account the targeted block. If the mining speed was > 1, then we considered it an axe by default. However this isn't possible with the anvil as no block is targeted.
This therefore leads to an inconsistency where tools may not be considered an axe in the anvil, but would when breaking a tree.

This change reverts it to a more basic check, this means : 

* Axes will be composed of the same tools regardless if the anvil is used or the item is used on a tree
* Less axes may be detected by default and you'll have to whitelist them manually