### PR TITLE
Do not apply speed multiplier when using shift down chopper enchantment (1.18.2 backport)

### DIFF
--- a/common/src/main/java/fr/raksrinana/fallingtree/common/config/enums/BreakMode.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/config/enums/BreakMode.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum BreakMode{
-	INSTANTANEOUS(true),
-	SHIFT_DOWN(false);
+	INSTANTANEOUS(true, true),
+	SHIFT_DOWN(false, false);
 	
 	private final boolean checkLeavesAround;
+	private final boolean applySpeedMultiplier;
 }

--- a/common/src/main/java/fr/raksrinana/fallingtree/common/tree/TreeHandler.java
+++ b/common/src/main/java/fr/raksrinana/fallingtree/common/tree/TreeHandler.java
@@ -84,7 +84,7 @@ public class TreeHandler{
 		if(!mod.getConfiguration().getTrees().isTreeBreaking()){
 			return Optional.empty();
 		}
-		if(mod.getConfiguration().getTrees().getBreakMode() != BreakMode.INSTANTANEOUS){
+		if(!getBreakMode(player.getMainHandItem()).isApplySpeedMultiplier()){
 			return Optional.empty();
 		}
 		if(!mod.isPlayerInRightState(player)){

--- a/wiki/Settings---Tools.asciidoc
+++ b/wiki/Settings---Tools.asciidoc
@@ -55,4 +55,6 @@ NOTE: Deny list takes over the values defined in allow list. So if you defined t
 - 2: Will take the same amount of time as if you'd break a tree with twice the amount of logs.
 - 0.5: Will take the same amount of time as if you'd break a tree with half the amount of logs.
 - 0: This is a special value and will take only the time of breaking one single log block.
+
+NOTE: This is only applied when INSTANTANEOUS break mode is used.
 |===


### PR DESCRIPTION
(cherry picked from commit 6ed9dce7d57098e7674228c40f1246d784958490)