### PR TITLE
Add support for Minecraft 1.20

### DIFF
--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[45,)"
+loaderVersion = "[46,)"
 issueTrackerURL = "https://github.com/${repoUser}/${repoName}/issues"
 license = "LGPL-3.0"
 
@@ -15,7 +15,7 @@ authors = "Rakambda"
 [[dependencies.fallingtree]]
 modId = "forge"
 mandatory = true
-versionRange = "[45,)"
+versionRange = "[46.0.1,)"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.fallingtree]]
@@ -27,6 +27,6 @@ side = "BOTH"
 [[dependencies.fallingtree]]
 modId = "cloth-config"
 mandatory = false
-versionRange = "[10.0.0,)"
+versionRange = "[11.0.99,)"
 ordering = "NONE"
 side = "CLIENT"

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -2,6 +2,6 @@
     "pack": {
         "description": "FallingTree",
         "pack_format": 13,
-        "forge:data_pack_format": 12
+        "forge:server_data_pack_format": 12
     }
 }

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,8 +1,7 @@
 {
     "pack": {
         "description": "FallingTree",
-        "pack_format": 12,
-        "forge:resource_pack_format": 12,
-        "forge:data_pack_format": 10
+        "pack_format": 13,
+        "forge:data_pack_format": 12
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ forgeMappingsVersion = "1.20"
 modmenu-version = "7.0.0"
 clothConfigVersion = "11.0.99"
 
-fabric-loom-version = "1.1.14"
+fabric-loom-version = "1.2.7"
 forge-plugin-version = "6.0.4"
 curse-version = "1.4.0"
 modrinth-version = "2.7.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ forge-version = "1.20-46.0.1"
 forgeMappingsVersion = "1.20"
 
 # Mod dependencies
-modmenu-version = "6.2.2"
+modmenu-version = "7.0.0"
 clothConfigVersion = "11.0.99"
 
 fabric-loom-version = "1.1.14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ modmenu-version = "7.0.0"
 clothConfigVersion = "11.0.99"
 
 fabric-loom-version = "1.2.7"
-forge-plugin-version = "6.0.4"
+forge-plugin-version = "6.0.6"
 curse-version = "1.4.0"
 modrinth-version = "2.7.5"
 names-version = "0.46.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,15 +7,15 @@ gson-version = "2.10.1"
 log4j2-version = "2.20.0"
 
 # Minecraft / Loaders
-minecraftVersion = "1.19.4"
-fabric-loader-version = "0.14.19"
-fabric-api-version = "0.78.0+1.19.4"
-forge-version = "1.19.4-45.0.46"
-forgeMappingsVersion = "1.19.3"
+minecraftVersion = "1.20"
+fabric-loader-version = "0.14.21"
+fabric-api-version = "0.83.0+1.20"
+forge-version = "1.20-46.0.1"
+forgeMappingsVersion = "1.20"
 
 # Mod dependencies
 modmenu-version = "6.2.2"
-clothConfigVersion = "10.0.96"
+clothConfigVersion = "11.0.99"
 
 fabric-loom-version = "1.1.14"
 forge-plugin-version = "6.0.4"


### PR DESCRIPTION
Updated versions of libs to match current libs available for minecraft 1.20. Tested it manually, nothing seems to brake. Have no idea how also change the mod version that it would build something else than 3.12.2, so a task for the future.
____
For some reason cant create new branch in base repo, so it is targeted against 1.19.4, please change it to a new branch if everything is fine. 