### PR TITLE
Fix fall animation break budget on 26.1.2

### DIFF
--- a/common/src/main/java/fr/rakambda/fallingtree/common/tree/breaking/FallingAnimationTreeBreakingHandler.java
+++ b/common/src/main/java/fr/rakambda/fallingtree/common/tree/breaking/FallingAnimationTreeBreakingHandler.java
@@ -81,7 +81,8 @@ public class FallingAnimationTreeBreakingHandler implements ITreeBreakingHandler
 		var lootHandler = new LootHandler(wantToBreakCount, mod.getConfiguration().getTrees().getTrunkLootPercentage());
 		var brokenCount = 0;
 		var breakablePartsLeft = wantToBreakCount;
-		for(var part : tree.getParts().stream().sorted(mod.getConfiguration().getTrees().getBreakOrder().getComparator()).toList()){
+        var breakableParts = tree.getParts().stream().sorted(mod.getConfiguration().getTrees().getBreakOrder().getComparator()).toList();
+		for(var part : breakableParts){
 			if(part.treePartType().isBreakable()){
 				if(breakablePartsLeft == 0){
 					break;

--- a/common/src/main/java/fr/rakambda/fallingtree/common/tree/breaking/FallingAnimationTreeBreakingHandler.java
+++ b/common/src/main/java/fr/rakambda/fallingtree/common/tree/breaking/FallingAnimationTreeBreakingHandler.java
@@ -5,6 +5,7 @@ import fr.rakambda.fallingtree.common.tree.AbortedResult;
 import fr.rakambda.fallingtree.common.tree.IBreakAttemptResult;
 import fr.rakambda.fallingtree.common.tree.SuccessResult;
 import fr.rakambda.fallingtree.common.tree.Tree;
+import fr.rakambda.fallingtree.common.tree.TreePartType;
 import fr.rakambda.fallingtree.common.wrapper.IBlockPos;
 import fr.rakambda.fallingtree.common.wrapper.IPlayer;
 import fr.rakambda.fallingtree.common.wrapper.IRandomSource;
@@ -78,41 +79,51 @@ public class FallingAnimationTreeBreakingHandler implements ITreeBreakingHandler
 		var scannedLeaves = new LinkedList<IBlockPos>();
 		var wantToBreakCount = Math.min(tree.getBreakableCount(), toolHandler.getMaxBreakCount());
 		var lootHandler = new LootHandler(wantToBreakCount, mod.getConfiguration().getTrees().getTrunkLootPercentage());
-		var brokenCount = tree.getParts().stream()
-				.sorted(mod.getConfiguration().getTrees().getBreakOrder().getComparator())
-				.limit(wantToBreakCount)
-				.mapToInt(part -> {
-					var logBlockPos = part.blockPos();
-					var logState = level.getBlockState(logBlockPos);
-					
-					if(!tree.getHitPos().equals(logBlockPos) && !mod.checkCanBreakBlock(level, logBlockPos, logState, player)){
-						return 0;
-					}
-					
-					player.awardItemUsed(tool.getItem());
-					if(config.dropLogsAsItems && (!player.isCreative() || mod.getConfiguration().isLootInCreative())){
-						logState.getBlock().playerDestroy(level, player, logBlockPos, logState, level.getBlockEntity(logBlockPos), tool, !part.treePartType().isIncludeInTree() || lootHandler.breakNewTrunk());
-					}
-					
-					var random = level.getRandom();
-					serverLevel.fallBlock(
-							logBlockPos,
-							!config.dropLogsAsItems,
-							config.vx.apply(random),
-							config.vy.apply(random),
-							config.vx.apply(random)
-					);
-					
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.below());
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.north());
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.east());
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.south());
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.west());
-					fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.above());
-					
-					return part.treePartType().isBreakable() ? 1 : 0;
-				})
-				.sum();
+		var brokenCount = 0;
+		var breakablePartsLeft = wantToBreakCount;
+		for(var part : tree.getParts().stream().sorted(mod.getConfiguration().getTrees().getBreakOrder().getComparator()).toList()){
+			if(part.treePartType().isBreakable()){
+				if(breakablePartsLeft == 0){
+					break;
+				}
+				breakablePartsLeft--;
+			}
+			else if(part.treePartType() != TreePartType.LOG_START || breakablePartsLeft == 0){
+				continue;
+			}
+			
+			var logBlockPos = part.blockPos();
+			var logState = level.getBlockState(logBlockPos);
+			
+			if(!tree.getHitPos().equals(logBlockPos) && !mod.checkCanBreakBlock(level, logBlockPos, logState, player)){
+				continue;
+			}
+			
+			player.awardItemUsed(tool.getItem());
+			if(config.dropLogsAsItems && (!player.isCreative() || mod.getConfiguration().isLootInCreative())){
+				logState.getBlock().playerDestroy(level, player, logBlockPos, logState, level.getBlockEntity(logBlockPos), tool, !part.treePartType().isIncludeInTree() || lootHandler.breakNewTrunk());
+			}
+			
+			var random = level.getRandom();
+			serverLevel.fallBlock(
+					logBlockPos,
+					!config.dropLogsAsItems,
+					config.vx.apply(random),
+					config.vy.apply(random),
+					config.vx.apply(random)
+			);
+			
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.below());
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.north());
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.east());
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.south());
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.west());
+			fallLeaf(scannedLeaves, player, serverLevel, 5, logBlockPos.above());
+			
+			if(part.treePartType().isBreakable()){
+				brokenCount++;
+			}
+		}
 		
 		var toolDamage = toolHandler.getActualDamage(brokenCount) - 1;
 		if(toolDamage > 0){


### PR DESCRIPTION
Fixing the topmost log sticking

## What changed
- fixed the falling-animation handler so `LOG_START` still participates in `FALL_*` animations
- changed the break-selection logic to stop after consuming the requested number of breakable parts instead of limiting the raw part stream
- kept the topmost real log in the selected break set for configs like `FALL_ITEM` + `LOWEST_FIRST`

## Why
A 26.1.2-specific regression investigation showed that the falling-animation handler was budgeting from `tree.getBreakableCount()` but iterating `tree.getParts()`. With `LOWEST_FIRST`, the non-breakable `LOG_START` entry could consume one of the limited slots, which left the top log behind.

A first-pass fix that switched the handler to `getBreakableParts()` avoided the skipped-top-log bug, but it also removed the chopped `LOG_START` block from the falling animation on Forge and NeoForge. This patch fixes both issues.

## Root cause
The selection cutoff was applied to the full sorted part list instead of to the count of breakable parts. That mixed two different notions of "count":
- break budget: breakable parts only
- animated stream: all parts, including `LOG_START`

The corrected logic iterates the sorted full part list, includes `LOG_START` only while it is still inside the selected breakable window, and stops once the requested number of breakable parts has been consumed.

## Impact
- `FALL_ITEM` no longer leaves the top log behind on 26.1.2 when the configuration selects logs from lowest to highest
- Forge and NeoForge keep animating the originally chopped log instead of letting it vanish immediately outside the falling animation
- the change is isolated to the shared falling-animation handler used by the `FALL_*` modes

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 25) PATH="$JAVA_HOME/bin:$PATH" ./gradlew :common:compileJava`
