### PR TITLE
Fix event renaming breaking change in NeoForge 26.1.2.21+ and handle `@OnlyIn` warning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ fabric-loader-version = "0.19.2"
 fabric-api-version = "0.145.4+26.1.2"
 forge-version = "26.1.2-64.0.4"
 forgeEventbusValidator-version = "7.0.5"
-neoforgeVersion = "26.1.2.1-beta"
+neoforgeVersion = "26.1.2.21-beta"
 
 # Mod dependencies
 modmenu-version = "18.0.0-alpha.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ fabric-loader-version = "0.19.2"
 fabric-api-version = "0.145.4+26.1.2"
 forge-version = "26.1.2-64.0.5"
 forgeEventbusValidator-version = "7.0.5"
-neoforgeVersion = "26.1.2.21-beta"
+neoforgeVersion = "26.1.2.29-beta"
 
 # Mod dependencies
 modmenu-version = "18.0.0-alpha.8"

--- a/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/client/cloth/ClothConfigHook.java
+++ b/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/client/cloth/ClothConfigHook.java
@@ -20,8 +20,6 @@ import fr.rakambda.fallingtree.common.config.real.cloth.ClothHookBase;
 import fr.rakambda.fallingtree.common.wrapper.IComponent;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import net.minecraft.network.chat.Component;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import org.jspecify.annotations.NonNull;
@@ -52,7 +50,6 @@ public class ClothConfigHook extends ClothHookBase{
 		});
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	public void fillConfigScreen(@NonNull ConfigBuilder builder, @NonNull Configuration config){
 		var reverseSneakingEntry = builder.entryBuilder()
 				.startEnumSelector(translatable(getFieldName(null, "sneakMode")), SneakMode.class, config.getSneakMode())
@@ -91,7 +88,6 @@ public class ClothConfigHook extends ClothHookBase{
 		fillEnchantmentConfigScreen(builder, config.getEnchantment());
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private void fillTreesConfigScreen(@NonNull ConfigBuilder builder, @NonNull TreeConfiguration config){
 		var breakModeEntry = builder.entryBuilder()
 				.startEnumSelector(translatable(getFieldName("trees", "breakMode")), BreakMode.class, config.getBreakMode())
@@ -294,7 +290,6 @@ public class ClothConfigHook extends ClothHookBase{
 		trees.addEntry(trunkLootPercentageEntry);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private void fillToolsConfigScreen(@NonNull ConfigBuilder builder, @NonNull ToolConfiguration config){
 		var ignoreToolsEntry = builder.entryBuilder()
 				.startBooleanToggle(translatable(getFieldName("tools", "ignoreTools")), config.isIgnoreTools())
@@ -362,7 +357,6 @@ public class ClothConfigHook extends ClothHookBase{
 		tools.addEntry(forceToolUsageEntry);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private void fillPlayerConfigScreen(@NonNull ConfigBuilder builder, @NonNull PlayerConfiguration config){
 		var allowedTagsEntry = builder.entryBuilder()
 				.startStrList(translatable(getFieldName("player", "allowedTags")), config.getAllowedTags())
@@ -375,7 +369,6 @@ public class ClothConfigHook extends ClothHookBase{
 		tools.addEntry(allowedTagsEntry);
 	}
 	
-	@OnlyIn(Dist.CLIENT)
 	private void fillEnchantmentConfigScreen(@NonNull ConfigBuilder builder, @NonNull EnchantmentConfiguration config){
 		var requireEnchantmentEntry = builder.entryBuilder()
 				.startBooleanToggle(translatable(getFieldName("enchantment", "requireEnchantment")), config.isRequireEnchantment())

--- a/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/common/FallingTreeCommonsImpl.java
+++ b/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/common/FallingTreeCommonsImpl.java
@@ -46,6 +46,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import org.jspecify.annotations.NonNull;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class FallingTreeCommonsImpl extends FallingTreeCommon<Direction>{
 	private final TagKey<Enchantment> chopperEnchantmentTag;
 	@Getter
 	private final Map<BreakMode, TagKey<Enchantment>> breakModeChopperEnchantmentTag;
-	private final List<BlockEvent.BreakEvent> breakEvents;
+	private final List<BreakBlockEvent> breakEvents;
 	
 	private final Map<IBlock, Boolean> isLogBlockCache;
 	private final Map<IBlock, Boolean> isLeafBlockCache;
@@ -226,9 +227,9 @@ public class FallingTreeCommonsImpl extends FallingTreeCommon<Direction>{
 	
 	@Override
 	public boolean isOwnEvent(@NonNull IBlockBreakEvent event){
-		var result = breakEvents.contains((BlockEvent.BreakEvent) event.getRaw()) || event instanceof FallingTreeBlockBreakEvent;
+		var result = breakEvents.contains((BreakBlockEvent) event.getRaw()) || event instanceof FallingTreeBlockBreakEvent;
 		if(result){
-			breakEvents.remove((BlockEvent.BreakEvent) event.getRaw());
+			breakEvents.remove((BreakBlockEvent) event.getRaw());
 		}
 		return result;
 	}

--- a/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/common/wrapper/BlockBreakEventWrapper.java
+++ b/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/common/wrapper/BlockBreakEventWrapper.java
@@ -5,14 +5,14 @@ import fr.rakambda.fallingtree.common.wrapper.IBlockPos;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import org.jspecify.annotations.NonNull;
 
 @RequiredArgsConstructor
 @ToString
 public class BlockBreakEventWrapper implements IBlockBreakEvent{
 	@Getter
-	private final BlockEvent.@NonNull BreakEvent raw;
+	private final @NonNull BreakBlockEvent raw;
 	
 	@Override
 	@NonNull

--- a/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/event/BlockBreakListener.java
+++ b/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/event/BlockBreakListener.java
@@ -12,6 +12,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import org.jspecify.annotations.NonNull;
 import javax.annotation.Nonnull;
 
@@ -44,7 +45,7 @@ public class BlockBreakListener{
 	}
 	
 	@SubscribeEvent
-	public void onBlockBreakEvent(@Nonnull BlockEvent.BreakEvent event){
+	public void onBlockBreakEvent(@Nonnull BreakBlockEvent event){
 		if(event.isCanceled()){
 			return;
 		}

--- a/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/event/FallingTreeBlockBreakEvent.java
+++ b/neoforge/src/main/java/fr/rakambda/fallingtree/neoforge/event/FallingTreeBlockBreakEvent.java
@@ -5,8 +5,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 
-public class FallingTreeBlockBreakEvent extends BlockEvent.BreakEvent{
+public class FallingTreeBlockBreakEvent extends BreakBlockEvent{
 	public FallingTreeBlockBreakEvent(Level level, BlockPos pos, BlockState state, Player player){
 		super(level, pos, state, player);
 	}

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -15,7 +15,7 @@ file="META-INF/neoforge.accesstransformer.cfg"
 [[dependencies.fallingtree]]
 modId="neoforge"
 type="required"
-versionRange="[26.1.2,)"
+versionRange="[26.1.2.21,)"
 ordering="NONE"
 side="BOTH"
 [[dependencies.fallingtree]]


### PR DESCRIPTION
Switched references of BlockEvent.BreakEvent to BreakBlockEvent and updated the neoforge version to 26.1.2.21-beta.